### PR TITLE
Revert renaming of delta serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## NEXT
+- revert - Rename ops to `delta` in (de)serialization
+
 ## 1.2.0
 - Rename ops to `delta` in (de)serialization
 

--- a/src/delta.rs
+++ b/src/delta.rs
@@ -18,7 +18,6 @@ use crate::{
 /// > Deltas can describe any Quill document, includes all text and formatting information, without the ambiguity and complexity of HTML.
 #[derive(Default, Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct Delta {
-    #[serde(rename = "delta")]
     ops: Vec<Op>,
 }
 
@@ -676,7 +675,7 @@ mod helpers_tests {
             .retain(4, Some(attributes!("bold" => true)))
             .delete(2);
         let input = json!({
-            "delta":[
+            "ops":[
                 {"insert": "Test"},
                 {"retain": 4, "attributes": {"bold": true}},
                 {"delete": 2}


### PR DESCRIPTION
Renaming of `ops` field caused breaking changes.